### PR TITLE
Fix replacement of dummy site-url

### DIFF
--- a/.github/workflows/deploy-to-ionos.yaml
+++ b/.github/workflows/deploy-to-ionos.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Render real site-url to all files
         run: |
           for file in `grep -rl 'https://IONOS_DEPLOY_NOW_SITE_URL' .`; do
-            sed -e 's|https://IONOS_DEPLOY_NOW_SITE_URL|${{ fromJson(steps.deployment.outputs.info).site-url }}|g'
+            sed -i $file -e 's|https://IONOS_DEPLOY_NOW_SITE_URL|${{ fromJson(steps.deployment.outputs.info).site-url }}|g'
           done
 
       - name: Render SSH user secret name


### PR DESCRIPTION
Thanks for your request @benstolle.

There was a bug in to code that generates the workflow. I've released a fix for this and new projects will now replace the site-url properly. If you want to fix it for your current project, you just need to apply this patch.